### PR TITLE
Add super admin reject API for production requests

### DIFF
--- a/src/controllers/ProductionRequestController.ts
+++ b/src/controllers/ProductionRequestController.ts
@@ -267,6 +267,37 @@ class ProductionRequestController {
       return res.status(500).json({ message: 'Sunucu hatası' });
     }
   }
+
+  /**
+   * Super admin - Talebi reddet
+   */
+  public static async superReject(req: Request, res: Response) {
+    try {
+      const requestId = parseInt(req.params.id, 10);
+      const existing = await ProductionRequestService.getRequestById(requestId);
+      if (!existing) {
+        return res.status(404).json({ message: 'Üretim talebi bulunamadı' });
+      }
+
+      const userRole = (req as any).userRole;
+      if (userRole !== 'superAdmin') {
+        return res.status(403).json({ message: 'Bu işlemi sadece super admin yapabilir' });
+      }
+
+      if (existing.status !== 'pending') {
+        return res
+          .status(400)
+          .json({ message: `Bu talep '${existing.status}' durumunda. Reddedilemez.` });
+      }
+
+      await ProductionRequestService.rejectRequest(requestId);
+
+      return res.json({ message: 'Üretim talebi reddedildi', requestId });
+    } catch (error) {
+      console.error('ProductionRequestController.superReject Error:', error);
+      return res.status(500).json({ message: 'Sunucu hatası' });
+    }
+  }
   public static async startProduction(req: Request, res: Response) {
     try {
       const requestId = parseInt(req.params.id, 10);

--- a/src/routes/productionRequestRoutes.ts
+++ b/src/routes/productionRequestRoutes.ts
@@ -45,6 +45,11 @@ productionRequestRouter.put('/:id/reject', authMiddleware, (req, res) => {
   Promise.resolve(ProductionRequestController.reject(req, res));
 });
 
+// PUT /api/productionRequests/:id/superReject
+productionRequestRouter.put('/:id/superReject', authMiddleware, (req, res) => {
+  Promise.resolve(ProductionRequestController.superReject(req, res));
+});
+
 /**
  * Opsiyonel: Üretim sürecini başlatma (#18)
  */


### PR DESCRIPTION
## Summary
- allow super admins to reject production requests
- expose `/api/productionRequests/:id/superReject` route

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684162d327cc832c8f6981f37783de9b