### PR TITLE
Add profile image handling and sample curl docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,29 @@ curl -X POST http://localhost:3000/api/auctions/bid \
 curl -X POST http://localhost:3000/api/auctions/invites/123/accept \
   -H "Authorization: Bearer <TOKEN>"
 ```
+
+## Update Profile Image
+```bash
+curl -X POST http://localhost:3000/api/profile/image \
+  -H "Authorization: Bearer <TOKEN>" \
+  -F image=@/path/to/avatar.png
+```
+
+## Delete Profile Image
+```bash
+curl -X DELETE http://localhost:3000/api/profile/image \
+  -H "Authorization: Bearer <TOKEN>"
+```
+
+## Admin: Create User
+```bash
+curl -X POST http://localhost:3000/api/users \
+  -H "Authorization: Bearer <ADMIN_TOKEN>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "email": "new@example.com",
+    "password": "Secret123",
+    "name": "New User",
+    "role_id": 2
+  }'
+```

--- a/database/migrations/2023_01_01_000011_add_profile_image.ts
+++ b/database/migrations/2023_01_01_000011_add_profile_image.ts
@@ -1,0 +1,13 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  return knex.schema.alterTable('users', (table) => {
+    table.string('profile_image', 200).nullable();
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  return knex.schema.alterTable('users', (table) => {
+    table.dropColumn('profile_image');
+  });
+}

--- a/src/controllers/ProfileController.ts
+++ b/src/controllers/ProfileController.ts
@@ -1,0 +1,46 @@
+import { Request, Response } from 'express';
+import pool from '../db';
+import fs from 'fs/promises';
+import { fileUrl } from '../utils/url';
+
+class ProfileController {
+  public static async uploadImage(req: Request, res: Response) {
+    try {
+      const userId = (req as any).userId;
+      if (!req.file) {
+        return res.status(400).json({ message: 'Görsel bulunamadı.' });
+      }
+      await pool.query('UPDATE users SET profile_image = ? WHERE id = ?', [req.file.path, userId]);
+      const url = fileUrl(req.protocol, req.get('host') || '', req.file.path);
+      return res.json({ message: 'Profil resmi güncellendi', path: url });
+    } catch (error) {
+      console.error('uploadImage Error:', error);
+      return res.status(500).json({ message: 'Sunucu hatası' });
+    }
+  }
+
+  public static async deleteImage(req: Request, res: Response) {
+    try {
+      const userId = (req as any).userId;
+      const [rows] = await pool.query('SELECT profile_image FROM users WHERE id = ?', [userId]);
+      if (!(rows as any[]).length) {
+        return res.status(404).json({ message: 'Kullanıcı bulunamadı' });
+      }
+      const imgPath = (rows as any[])[0].profile_image as string | null;
+      if (imgPath) {
+        try {
+          await fs.unlink(imgPath);
+        } catch (err) {
+          console.error('unlink error:', err);
+        }
+      }
+      await pool.query('UPDATE users SET profile_image = NULL WHERE id = ?', [userId]);
+      return res.json({ message: 'Profil resmi silindi' });
+    } catch (error) {
+      console.error('deleteImage Error:', error);
+      return res.status(500).json({ message: 'Sunucu hatası' });
+    }
+  }
+}
+
+export default ProfileController;

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ import userRouter from './routes/userRoutes';
 import productRouter from './routes/productRoutes';
 import settingRouter from './routes/settingRoutes';
 import imageRouter from './routes/imageRoutes';
+import profileRouter from './routes/profileRoutes';
 import { initAuctionSocket } from './sockets/AuctionSocket';
 import path from 'path';
 // Middleware
@@ -80,6 +81,7 @@ app.use('/users', userRouter);
 app.use('/products', productRouter);
 app.use('/settings', settingRouter);
 app.use('/images', imageRouter);
+app.use('/profile', profileRouter);
 app.use('/productAttributes', productAttributeRouter);
 app.use('/dashboard', dashboardRouter);
 

--- a/src/routes/profileRoutes.ts
+++ b/src/routes/profileRoutes.ts
@@ -1,0 +1,16 @@
+import { Router } from 'express';
+import ProfileController from '../controllers/ProfileController';
+import { authMiddleware } from '../middlewares/authMiddleware';
+import { upload } from '../utils/multerConfig';
+
+const router = Router();
+
+router.post('/image', authMiddleware, upload.single('image'), (req, res) => {
+  Promise.resolve(ProfileController.uploadImage(req, res));
+});
+
+router.delete('/image', authMiddleware, (req, res) => {
+  Promise.resolve(ProfileController.deleteImage(req, res));
+});
+
+export default router;

--- a/src/services/ProductService.ts
+++ b/src/services/ProductService.ts
@@ -1,4 +1,5 @@
 import pool from '../db';
+import { findImagesForProduct } from '../utils/productImages';
 
 class ProductService {
   public static async createProduct(
@@ -55,6 +56,10 @@ class ProductService {
       ...r,
       images: r.images ? (r.images as string).split(',') : []
     }));
+    for (const p of products) {
+      const extra = findImagesForProduct(p.name);
+      p.images = Array.from(new Set([...p.images, ...extra]));
+    }
     return products;
   }
 
@@ -77,6 +82,8 @@ class ProductService {
     product.attributes = Object.fromEntries(
       (attrs as any[]).map((r) => [r.attrKey, r.attrValue])
     );
+    const extra = findImagesForProduct(product.name);
+    product.images = Array.from(new Set([...product.images, ...extra]));
     return product;
   }
 

--- a/src/utils/productImages.ts
+++ b/src/utils/productImages.ts
@@ -1,0 +1,11 @@
+import fs from 'fs';
+import path from 'path';
+
+export function findImagesForProduct(name: string): string[] {
+  const uploadsDir = path.join(__dirname, '..', '..', 'uploads');
+  if (!fs.existsSync(uploadsDir)) return [];
+  const files = fs.readdirSync(uploadsDir);
+  const prefix = name.toLowerCase().replace(/\s+/g, ' ').trim();
+  const matched = files.filter((f) => f.toLowerCase().startsWith(prefix));
+  return matched.map((f) => path.join('uploads', f));
+}


### PR DESCRIPTION
## Summary
- support user profile image upload and deletion
- automatically match product images from the uploads folder
- expose new `/profile` API routes
- document the new APIs with example curl requests
- add a migration to store profile images

## Testing
- `npx tsc --noEmit`
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68778d8676d0832c9c80dbb1dd3cc371