### PR TITLE
Serve category images in auction details

### DIFF
--- a/src/controllers/AuctionController.ts
+++ b/src/controllers/AuctionController.ts
@@ -130,14 +130,6 @@ const userRole = (req as any).userRole;
           product.images = (product.images || []).map((img: string) =>
             fileUrl(req.protocol, req.get('host') || '', img)
           );
-          auction.product = product;        }
-      }
-      if (auction.product_id) {
-        const product = await ProductService.getById(auction.product_id);
-        if (product) {
-          product.images = (product.images || []).map((img: string) =>
-            fileUrl(req.protocol, req.get('host') || '', img)
-          );
           auction.product = product;
         }
       }

--- a/src/services/ProductService.ts
+++ b/src/services/ProductService.ts
@@ -1,5 +1,5 @@
 import pool from '../db';
-import { findImagesForProduct } from '../utils/productImages';
+import { findImagesForProduct, findImagesForCategory } from '../utils/productImages';
 
 class ProductService {
   public static async createProduct(
@@ -57,8 +57,9 @@ class ProductService {
       images: r.images ? (r.images as string).split(',') : []
     }));
     for (const p of products) {
-      const extra = findImagesForProduct(p.name);
-      p.images = Array.from(new Set([...p.images, ...extra]));
+      const extraName = findImagesForProduct(p.name);
+      const extraCategory = findImagesForCategory(p.category);
+      p.images = Array.from(new Set([...p.images, ...extraName, ...extraCategory]));
     }
     return products;
   }
@@ -82,8 +83,9 @@ class ProductService {
     product.attributes = Object.fromEntries(
       (attrs as any[]).map((r) => [r.attrKey, r.attrValue])
     );
-    const extra = findImagesForProduct(product.name);
-    product.images = Array.from(new Set([...product.images, ...extra]));
+    const extraName = findImagesForProduct(product.name);
+    const extraCategory = findImagesForCategory(product.category);
+    product.images = Array.from(new Set([...product.images, ...extraName, ...extraCategory]));
     return product;
   }
 

--- a/src/utils/productImages.ts
+++ b/src/utils/productImages.ts
@@ -1,6 +1,13 @@
 import fs from 'fs';
 import path from 'path';
 
+const CATEGORY_IMAGE_MAP: Record<string, string> = {
+  'flour': 'Sunflower oil ORTA.png',
+  'spaghetti': 'spaghetti ORTA_.png',
+  'fresh egg': 'fresh egg ORTA.png',
+  'wheat flour': 'wheat flour orta.png'
+};
+
 export function findImagesForProduct(name: string): string[] {
   const uploadsDir = path.join(__dirname, '..', '..', 'uploads');
   if (!fs.existsSync(uploadsDir)) return [];
@@ -8,4 +15,17 @@ export function findImagesForProduct(name: string): string[] {
   const prefix = name.toLowerCase().replace(/\s+/g, ' ').trim();
   const matched = files.filter((f) => f.toLowerCase().startsWith(prefix));
   return matched.map((f) => path.join('uploads', f));
+}
+
+export function findImagesForCategory(category: string): string[] {
+  const uploadsDir = path.join(__dirname, '..', '..', 'uploads');
+  if (!fs.existsSync(uploadsDir)) return [];
+  const files = fs.readdirSync(uploadsDir);
+  const prefix = category.toLowerCase().replace(/\s+/g, ' ').trim();
+  const matched = files.filter((f) => f.toLowerCase().startsWith(prefix));
+  const mapped = CATEGORY_IMAGE_MAP[prefix];
+  if (mapped && files.includes(mapped) && !matched.includes(mapped)) {
+    matched.push(mapped);
+  }
+  return Array.from(new Set(matched)).map((f) => path.join('uploads', f));
 }


### PR DESCRIPTION
## Summary
- fetch images by product category in addition to product name
- expose new `findImagesForCategory` helper
- remove redundant product lookup when showing auction details
- map certain categories to specific default images

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6877ccf2f1f8832c8aa42159fb4525ca