### PR TITLE
Add category-based product images and ensure auction product fields

### DIFF
--- a/src/utils/productImages.ts
+++ b/src/utils/productImages.ts
@@ -2,9 +2,11 @@ import fs from 'fs';
 import path from 'path';
 
 const CATEGORY_IMAGE_MAP: Record<string, string> = {
-  'flour': 'Sunflower oil ORTA.png',
-  'spaghetti': 'spaghetti ORTA_.png',
-  'fresh egg': 'fresh egg ORTA.png',
+  'flour': 'wheat flour orta.png',
+  'spaghetti': 'spaghetti ANA.png',
+  'fresh egg': 'fresh egg.png',
+  'sunflower oil': 'sunflower oil.png',
+  'short-cut pasta': 'spaghetti ANA.png',
   'wheat flour': 'wheat flour orta.png'
 };
 


### PR DESCRIPTION
## Summary
- Map product categories to specific image files and return URLs in a new `product_image` field
- Join products in auction queries to populate product and customer fields
- Fill missing product identifiers and names from product records

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8271cb4cc832cad8268485a86e672