### PR TITLE
chore: use production domains for email links

### DIFF
--- a/.env
+++ b/.env
@@ -9,7 +9,7 @@ JWT_SECRET=super_secret_jwt_key
 
 # Sunucu portu
 PORT=3000
-BASE_URL=http://localhost:3000
+BASE_URL=https://api.demaxtore.com
 
 # Mail (NotificationService)
 MAIL_HOST=smtp.yandex.com.tr

--- a/src/services/AuctionInviteService.ts
+++ b/src/services/AuctionInviteService.ts
@@ -32,7 +32,7 @@ class AuctionInviteService {
           const email = (rows as any[])[0].email;
           const subject = 'Yeni Açık Artırma Daveti';
           const auctionLink = `${process.env.FRONTEND_URL || 'https://panel.demaxtore.com'}/auctions/${auctionId}`;
-          const acceptLink = `${process.env.BASE_URL || 'http://api.demaxtore.com'}/auctions/invites/${inviteId}/accept`;
+          const acceptLink = `${process.env.BASE_URL || 'https://api.demaxtore.com'}/auctions/invites/${inviteId}/accept`;
           const text = `İhaleye katılmak için: ${auctionLink} - Kabul için: ${acceptLink}`;
           const html = `<p>Merhaba,</p>
             <p>${auctionId} numaralı açık artırmaya davet edildiniz.</p>


### PR DESCRIPTION
## Summary
- point BASE_URL to https://api.demaxtore.com for backend links
- default invite acceptance links to api.demaxtore.com

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a82949f5ac832cae430eccf314935c