### PR TITLE
feat: enable accepting invites via email link

### DIFF
--- a/src/controllers/AuctionInviteController.ts
+++ b/src/controllers/AuctionInviteController.ts
@@ -102,32 +102,20 @@ class AuctionInviteController {
   }
 
   /**
-   * Daveti kabul etmek için kısayol endpointi
-   * POST /api/auctions/invites/:inviteId/accept
+   * Daveti e-posta linki ile kabul et
+   * GET /api/auctions/invites/:inviteId/accept
    */
   public static async accept(req: Request, res: Response) {
     try {
       const inviteId = parseInt(req.params.inviteId, 10);
-      const userRole = (req as any).userRole;
-      const userId = (req as any).userId;
-
-      if (userRole !== 'manufacturer') {
-        return res.status(403).json({ message: 'Bu işlemi sadece üreticiler yapabilir' });
-      }
-
-      const invite = await AuctionInviteService.getInviteById(inviteId);
-      if (!invite) {
-        return res.status(404).json({ message: 'Davet kaydı bulunamadı' });
-      }
-      if (invite.manufacturerId !== userId) {
-        return res.status(403).json({ message: 'Bu davet size ait değil' });
-      }
 
       const updated = await AuctionInviteService.respondToInvite(inviteId, 'accepted');
       if (!updated) {
-        return res.status(500).json({ message: 'Davet durumu güncellenemedi' });
+        return res.status(404).json({ message: 'Davet kaydı bulunamadı' });
       }
-      return res.json({ message: 'Davet kabul edildi', inviteId });
+
+      const redirectUrl = `${process.env.FRONTEND_URL || 'https://panel.demaxtore.com'}/auctions/list`;
+      return res.redirect(redirectUrl);
     } catch (error) {
       console.error('AuctionInviteController.accept Error:', error);
       return res.status(500).json({ message: 'Sunucu hatası' });

--- a/src/routes/auctionRoutes.ts
+++ b/src/routes/auctionRoutes.ts
@@ -67,9 +67,9 @@ auctionRouter.post('/respondInvite', authMiddleware, (req, res) => {
   Promise.resolve(AuctionInviteController.respond(req, res));
 });
 
-auctionRouter.post('/invites/:inviteId/accept', authMiddleware, (req, res) => {
-  Promise.resolve(AuctionInviteController.accept(req, res));
-});
+  auctionRouter.get('/invites/:inviteId/accept', (req, res) => {
+    Promise.resolve(AuctionInviteController.accept(req, res));
+  });
 
 
 


### PR DESCRIPTION
## Summary
- allow GET /auctions/invites/:inviteId/accept without auth
- accept invite and redirect to panel's auctions list

## Testing
- `npm test` *(fails: npm: command not found)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble Release' does not have a Release file)*

------
https://chatgpt.com/codex/tasks/task_e_68a832654410832ca046f57f7dedd77a