### PR TITLE
Fix production request status calculation

### DIFF
--- a/src/services/ProductionRequestService.ts
+++ b/src/services/ProductionRequestService.ts
@@ -40,10 +40,8 @@ class ProductionRequestService {
         p.updatedAt AS productUpdatedAt,
         u.name AS customerName, u.email AS customerEmail,
         CASE
-          WHEN pr.status = 'rejected' THEN 'rejected'
-          WHEN a.status = 'ended' THEN 'completed'
-          WHEN a.id IS NOT NULL THEN 'accepted'
-          ELSE 'pending'
+          WHEN pr.status = 'accepted' AND a.status = 'ended' THEN 'completed'
+          ELSE pr.status
         END AS status
         FROM production_requests pr
         LEFT JOIN products p ON pr.product_id = p.id
@@ -72,10 +70,8 @@ class ProductionRequestService {
         p.updatedAt AS productUpdatedAt,
         u.name AS customerName, u.email AS customerEmail,
         CASE
-          WHEN pr.status = 'rejected' THEN 'rejected'
-          WHEN a.status = 'ended' THEN 'completed'
-          WHEN a.id IS NOT NULL THEN 'accepted'
-          ELSE 'pending'
+          WHEN pr.status = 'accepted' AND a.status = 'ended' THEN 'completed'
+          ELSE pr.status
         END AS status
         FROM production_requests pr
         LEFT JOIN products p ON pr.product_id = p.id
@@ -105,10 +101,8 @@ class ProductionRequestService {
         p.updatedAt AS productUpdatedAt,
         u.name AS customerName, u.email AS customerEmail,
         CASE
-          WHEN pr.status = 'rejected' THEN 'rejected'
-          WHEN a.status = 'ended' THEN 'completed'
-          WHEN a.id IS NOT NULL THEN 'accepted'
-          ELSE 'pending'
+          WHEN pr.status = 'accepted' AND a.status = 'ended' THEN 'completed'
+          ELSE pr.status
         END AS status
         FROM production_requests pr
         LEFT JOIN products p ON pr.product_id = p.id


### PR DESCRIPTION
## Summary
- rely on production request status instead of auction presence when listing requests
- mark completed requests only when an accepted request's auction has ended

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8612232a0832ca72ad1e0ef62d05c