### PR TITLE
Fix production request status calculation

### DIFF
--- a/src/controllers/AuctionController.ts
+++ b/src/controllers/AuctionController.ts
@@ -292,7 +292,14 @@ const userRole = (req as any).userRole;
       ]);
 
       const newId = (result as any).insertId;
-         if (Array.isArray(supplierIds) && supplierIds.length > 0) {
+
+      // Açık artırma oluşturulduğunda ilgili üretim talebini kabul et
+      await pool.query(
+        `UPDATE production_requests SET status = 'accepted' WHERE id = ?`,
+        [productionId]
+      );
+
+      if (Array.isArray(supplierIds) && supplierIds.length > 0) {
         await AuctionInviteService.inviteManufacturers(newId, supplierIds);
       }
       return res.status(201).json({ message: 'Açık artırma oluşturuldu', auctionId: newId });

--- a/src/services/AuctionService.ts
+++ b/src/services/AuctionService.ts
@@ -32,7 +32,15 @@ class AuctionService {
       baseCurrency,
       sortDirection,
       productionId
-    ]);    const newId = (result as any).insertId;
+    ]);
+    const newId = (result as any).insertId;
+
+    // Üretim talebi oluşturulan açık artırma ile kabul edilmiş sayılır
+    await pool.query(
+      `UPDATE production_requests SET status = 'accepted' WHERE id = ?`,
+      [productionId]
+    );
+
     return newId;
   }
 

--- a/src/services/ProductionRequestService.ts
+++ b/src/services/ProductionRequestService.ts
@@ -40,10 +40,8 @@ class ProductionRequestService {
         p.updatedAt AS productUpdatedAt,
         u.name AS customerName, u.email AS customerEmail,
         CASE
-          WHEN pr.status = 'rejected' THEN 'rejected'
-          WHEN a.status = 'ended' THEN 'completed'
-          WHEN a.id IS NOT NULL THEN 'accepted'
-          ELSE 'pending'
+          WHEN pr.status = 'accepted' AND a.status = 'ended' THEN 'completed'
+          ELSE pr.status
         END AS status
         FROM production_requests pr
         LEFT JOIN products p ON pr.product_id = p.id
@@ -72,10 +70,8 @@ class ProductionRequestService {
         p.updatedAt AS productUpdatedAt,
         u.name AS customerName, u.email AS customerEmail,
         CASE
-          WHEN pr.status = 'rejected' THEN 'rejected'
-          WHEN a.status = 'ended' THEN 'completed'
-          WHEN a.id IS NOT NULL THEN 'accepted'
-          ELSE 'pending'
+          WHEN pr.status = 'accepted' AND a.status = 'ended' THEN 'completed'
+          ELSE pr.status
         END AS status
         FROM production_requests pr
         LEFT JOIN products p ON pr.product_id = p.id
@@ -105,10 +101,8 @@ class ProductionRequestService {
         p.updatedAt AS productUpdatedAt,
         u.name AS customerName, u.email AS customerEmail,
         CASE
-          WHEN pr.status = 'rejected' THEN 'rejected'
-          WHEN a.status = 'ended' THEN 'completed'
-          WHEN a.id IS NOT NULL THEN 'accepted'
-          ELSE 'pending'
+          WHEN pr.status = 'accepted' AND a.status = 'ended' THEN 'completed'
+          ELSE pr.status
         END AS status
         FROM production_requests pr
         LEFT JOIN products p ON pr.product_id = p.id


### PR DESCRIPTION
## Summary
- rely on production request status instead of auction presence when listing requests
- mark completed requests only when an accepted request's auction has ended
- accept production request once an auction is created for it

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8612232a0832ca72ad1e0ef62d05c