### PR TITLE
Prevent duplicate production request records

### DIFF
--- a/src/services/ProductionRequestService.ts
+++ b/src/services/ProductionRequestService.ts
@@ -46,7 +46,10 @@ class ProductionRequestService {
         FROM production_requests pr
         LEFT JOIN products p ON pr.product_id = p.id
         LEFT JOIN users u ON pr.customer_id = u.id
-        LEFT JOIN auctions a ON a.productionId = pr.id
+        LEFT JOIN (
+          SELECT productionId, status FROM auctions GROUP BY productionId
+        ) a ON a.productionId = pr.id
+        GROUP BY pr.id
         ORDER BY pr.id DESC
       `;
     const [rows] = await pool.query(sql);
@@ -76,8 +79,11 @@ class ProductionRequestService {
         FROM production_requests pr
         LEFT JOIN products p ON pr.product_id = p.id
         LEFT JOIN users u ON pr.customer_id = u.id
-        LEFT JOIN auctions a ON a.productionId = pr.id
+        LEFT JOIN (
+          SELECT productionId, status FROM auctions GROUP BY productionId
+        ) a ON a.productionId = pr.id
         WHERE pr.customer_id = ?
+        GROUP BY pr.id
         ORDER BY pr.id DESC
       `;
     const [rows] = await pool.query(sql, [customerId]);
@@ -107,8 +113,11 @@ class ProductionRequestService {
         FROM production_requests pr
         LEFT JOIN products p ON pr.product_id = p.id
         LEFT JOIN users u ON pr.customer_id = u.id
-        LEFT JOIN auctions a ON a.productionId = pr.id
+        LEFT JOIN (
+          SELECT productionId, status FROM auctions GROUP BY productionId
+        ) a ON a.productionId = pr.id
         WHERE pr.id = ?
+        GROUP BY pr.id
       `;
     const [rows] = await pool.query(sql, [requestId]);
     if (!(rows as any[]).length) return null;


### PR DESCRIPTION
## Summary
- use a grouped auctions subquery when joining in production request queries
- group by production request id to avoid duplicate rows

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8672211cc832c906d0b1b0d6f13ba